### PR TITLE
ギーカーモードにuniform sampler2D b;を含むように修正

### DIFF
--- a/src/fragmen.js
+++ b/src/fragmen.js
@@ -18,7 +18,7 @@ export class Fragmen {
      * ギーカーモード時に先頭に付与されるフラグメントシェーダのコード
      * @type {string}
      */
-    static get GEEKER_CHUNK(){return 'precision highp float;uniform vec2 r;uniform vec2 m;uniform float t;\n';}
+    static get GEEKER_CHUNK(){return 'precision highp float;uniform vec2 r;uniform vec2 m;uniform float t;uniform sampler2D b;\n';}
 
     /**
      * constructor of fragmen.js


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23691696/79455568-063e1300-8028-11ea-9d24-b35627a199d6.png)

ギーカーモード時の定義にbackbufferが含まれていなかったので追加しました。