### PR TITLE
fix #6 caused by redundant draw() calls

### DIFF
--- a/src/fragmen.js
+++ b/src/fragmen.js
@@ -402,10 +402,12 @@ void main(){
         this.uniLocation.sound = this.gl.getUniformLocation(this.program, sound);
         this.uniLocation.sampler = this.gl.getUniformLocation(this.program, backbuffer);
         this.attLocation = this.gl.getAttribLocation(this.program, 'p');
-        this.run = true;
         this.mousePosition = [0.0, 0.0];
         this.startTime = Date.now();
-        this.draw();
+        if(!this.run){
+            this.run = true;
+            this.draw();
+        }
     }
 
     /**


### PR DESCRIPTION
`reset` が呼ばれた時に新たに `this.draw()` を行っていますが
https://github.com/doxas/twigl/blob/39011756d572591165f95504914dcd7109206e29/src/fragmen.js#L408
それに拘らずもともと `draw()` が自身を `requestAnimationFrame` で呼ぶループを完結しているので
https://github.com/doxas/twigl/blob/39011756d572591165f95504914dcd7109206e29/src/fragmen.js#L416

もともと生きていた `draw` が回りつつ、新たに `this.draw()` によってループを増やしているようです (つまり今まで `reset` した回数だけ同時に `draw` している)

恐らく `draw()` が基本的に1本走っている状況で良いかと思ったので複数走らないようにガードをつけました (プロファイラを見る限りは意図通り動作しています)