### PR TITLE
Make (optional) declaration of main() possible in geekest modes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ In this mode, there is no need to declare precision and uniform. They are automa
 
 ### geekest:
 
-In this mode, the description of "void main(){}" can be omitted, and "gl_FragCoord" can be described as "FC". In addition, a variety of GLSL snippets are available.
+In this mode, the description of "void main(){}" may be omitted (or not), and "gl_FragCoord" can be described as "FC". In addition, a variety of GLSL snippets are available.
 
 For more information, please see below.
 

--- a/src/fragmen.js
+++ b/src/fragmen.js
@@ -928,8 +928,10 @@ void main(){
                 break;
             case Fragmen.MODE_GEEKEST:
                 chunkOut = Fragmen.GEEKEST_CHUNK;
-                chunkMain = 'void main(){\n'
-                chunkClose = '\n}'
+                if (!code.includes('void main()')) {
+                    chunkMain = 'void main(){\n'
+                    chunkClose = '\n}'
+                }
                 break;
             case Fragmen.MODE_CLASSIC_300:
             case Fragmen.MODE_GEEK_300:
@@ -948,14 +950,18 @@ void main(){
             case Fragmen.MODE_GEEKEST_300:
                 chunk300 = Fragmen.ES_300_CHUNK;
                 chunkOut = Fragmen.GEEKEST_CHUNK.substr(0, Fragmen.GEEKEST_CHUNK.length - 1) + Fragmen.GEEKEST_OUT_CHUNK;
-                chunkMain = 'void main(){\n'
-                chunkClose = '\n}'
+                if (!code.includes('void main()')) {
+                    chunkMain = 'void main(){\n'
+                    chunkClose = '\n}'
+                }
                 break;
             case Fragmen.MODE_GEEKEST_MRT:
                 chunk300 = Fragmen.ES_300_CHUNK;
                 chunkOut = Fragmen.GEEKEST_MRT_CHUNK.substr(0, Fragmen.GEEKEST_MRT_CHUNK.length - 1) + Fragmen.GEEKEST_OUT_MRT_CHUNK;
-                chunkMain = 'void main(){\n'
-                chunkClose = '\n}'
+                if (!code.includes('void main()')) {
+                    chunkMain = 'void main(){\n'
+                    chunkClose = '\n}'
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
- if the code includes `void main()` then it avoids wrapping it,
  which allows you to define helper functions beforehand.

Addresses #19.
