### PR TITLE
fix: Fix magin above eyeiconwrap

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -108,10 +108,13 @@ body {
 #hidemenuicon .showmenu {
     display: inherit;
 }
+#globaliconcolumnmargin {
+    margin: auto 0px;
+}
 #eyeiconwrap {
     background-color: rgba(64, 64, 64, 0.5);
     border-radius: 20px;
-    margin: auto 0px 8px;
+    margin: 8px 0px 0px;
     padding: 10px 8px;
     width: 40px;
     height: 60px;
@@ -125,7 +128,7 @@ body {
 #stariconwrap {
     background-color: rgba(64, 64, 64, 0.5);
     border-radius: 20px;
-    margin: 0px;
+    margin: 8px 0px 0px;
     padding: 10px 8px;
     width: 40px;
     height: 60px;

--- a/public/index.html
+++ b/public/index.html
@@ -57,6 +57,7 @@
                         <div id="noteicon" class="globaliconinner" title="import audio from local">
                             <img src="./resource/note.svg">
                         </div>
+                        <div id="globaliconcolumnmargin"></div>
                         <div id="eyeiconwrap">
                             <img src="./resource/eye.svg">
                             <div id="eyecounterwrap">


### PR DESCRIPTION
### 説明

割れ窓修正。broadcastモードで表示される、右上視聴者数アイコンのマージンが壊れてたので、これを修正しました。

どうせ縦幅が限界まで狭くてアイコンが収まりきっていない場合のお話なので、そもそもデザインを改善する必要はありますが……
1920x1080の環境でDevToolsを下付けで表示しているときに再現。

### スクリーンショット

|before|after|
|:-|:-|
|![image](https://user-images.githubusercontent.com/7824814/208701118-4305e76b-a563-4c74-96c6-e3f4e8a060b6.png)|![image](https://user-images.githubusercontent.com/7824814/208701590-2a0c0aab-5d2f-4d9d-a5b2-a49c5cd3020c.png)|

### レビュー観点

- [ ] この修正は本当に必要ですか？
    - 上記に書いた通り、いずれにせよデザイン修正が必要そうなので、あんまり今やっても意味のない変更の可能性はあります。
    - とはいえ、diffは小さく、難しいこともやっていない認識です。
