### PR TITLE
Improve fullscreen behavior

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -41,7 +41,7 @@ body {
 #wrap.overlay #canvaswrap {
     height: 100%;
 }
-#canvaswrap.fullheight {
+#wrap.hide #canvaswrap {
     height: 100%;
 }
 #globaliconwrap {
@@ -96,17 +96,26 @@ body {
 .globaliconinner:hover img {
     opacity: 0.8;
 }
-#hidemenuicon.hide .hidemenu {
-    display: inherit;
-}
-#hidemenuicon.hide .showmenu {
+#wrap.hide #broadcasticon {
     display: none;
 }
-#hidemenuicon .hidemenu {
+#wrap.hide #fullscreenicon {
     display: none;
 }
-#hidemenuicon .showmenu {
+#wrap.hide #hidemenuicon {
+    display: none;
+}
+#showmenuicon {
+    display: none;
+}
+#wrap.hide #showmenuicon {
     display: inherit;
+}
+#wrap.hide #togglemenuicon {
+    display: none;
+}
+#wrap.hide #noteicon {
+    display: none;
 }
 #eyeiconwrap {
     background-color: rgba(64, 64, 64, 0.5);
@@ -305,6 +314,9 @@ body {
     max-height: 100%;
     flex-direction: column;
     position: absolute;
+}
+#wrap.hide #editorwrap {
+    display: none;
 }
 #interface {
     width: 100%;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -99,9 +99,6 @@ body {
 #wrap.hide #broadcasticon {
     display: none;
 }
-#wrap.hide #fullscreenicon {
-    display: none;
-}
 #wrap.hide #hidemenuicon {
     display: none;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -32,9 +32,6 @@ body {
     position: relative;
     overflow: hidden;
 }
-#canvaswrap.fullscreen {
-    height: 100%;
-}
 #canvaswrap canvas {
     position: absolute;
 }
@@ -42,6 +39,9 @@ body {
     height: 100%;
 }
 #wrap.hide #canvaswrap {
+    height: 100%;
+}
+#wrap.fullscreen #canvaswrap {
     height: 100%;
 }
 #globaliconwrap {
@@ -62,7 +62,7 @@ body {
     flex-direction: column;
     justify-content: flex-start;
 }
-#globaliconcolumn.invisible {
+#wrap.fullscreen #globaliconcolumn {
     display: none;
 }
 .globaliconinner {
@@ -305,9 +305,6 @@ body {
     flex-direction: row;
     position: relative;
 }
-#editorwrap.invisible {
-    display: none;
-}
 #wrap.overlay #editorwrap {
     width: 100%;
     min-height: 100%;
@@ -316,6 +313,9 @@ body {
     position: absolute;
 }
 #wrap.hide #editorwrap {
+    display: none;
+}
+#wrap.fullscreen #editorwrap {
     display: none;
 }
 #interface {

--- a/public/index.html
+++ b/public/index.html
@@ -47,8 +47,10 @@
                         <div id="fullscreenicon" class="globaliconinner" title="fullscreen mode">
                             <img src="./resource/fullscreen.svg">
                         </div>
-                        <div id="hidemenuicon" class="globaliconinner hide" title="hide editor">
+                        <div id="hidemenuicon" class="globaliconinner" title="hide editor">
                             <img class="hidemenu" src="./resource/hidemenu.svg">
+                        </div>
+                        <div id="showmenuicon" class="globaliconinner" title="show editor">
                             <img class="showmenu" src="./resource/showmenu.svg">
                         </div>
                         <div id="togglemenuicon" class="globaliconinner" title="toggle edit mode">

--- a/src/registerCursorTimeout.js
+++ b/src/registerCursorTimeout.js
@@ -1,0 +1,34 @@
+/** 2秒後にカーソルを非表示に */
+const TIMEOUT_MS = 2000;
+
+/**
+ * DOMに対して、カーソルを最後に動かしてから一定時間後にカーソルを消す処理を追加
+ *
+ * @param {HTMLElement} element
+ * @returns {() => void} カーソルを表示し、DOMに追加した処理を削除するための関数
+ */
+export function registerCursorTimeout(element) {
+  let timeoutId;
+
+  const showCursorAndSetCursorTimeout = () => {
+    element.style.cursor = 'inherit';
+
+    if (timeoutId != null) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      element.style.cursor = 'none';
+    }, TIMEOUT_MS);
+  };
+
+  element.addEventListener('pointermove', showCursorAndSetCursorTimeout);
+
+  return () => {
+    element.removeEventListener('pointermove', showCursorAndSetCursorTimeout);
+
+    clearTimeout(timeoutId);
+
+    element.style.cursor = 'inherit';
+  };
+}

--- a/src/script.js
+++ b/src/script.js
@@ -5,6 +5,7 @@ import {Fragmen} from './fragmen.js';
 import {Onomat} from './onomat.js';
 import {Musician} from './music.js';
 import {FireDB} from './firedb.js';
+import {registerCursorTimeout} from './registerCursorTimeout.js';
 
 import * as firebase from 'firebase/app';
 import 'firebase/database';
@@ -83,6 +84,9 @@ let channelData = null;           // チャンネルのデータを保持
 let starData = null;              // スターに関するデータを保持
 let viewerData = null;            // 視聴者数に関するデータを保持
 let editorFontSize = 17;          // エディタのフォントサイズ
+
+/** {@link registerCursorTimeout} で追加した処理を消す関数 */
+let unregisterCursorTimeout = null;
 
 // fragmen.js 用のオプションの雛形
 const FRAGMEN_OPTION = {
@@ -2281,6 +2285,10 @@ function exitFullscreen(){
 function exitFullscreenMode(){
     wrap.classList.remove('fullscreen');
 
+    if (unregisterCursorTimeout != null) {
+        unregisterCursorTimeout();
+    }
+
     editor.resize();
     audioEditor.resize();
     resize();
@@ -2300,11 +2308,13 @@ function requestFullscreenMode(){
     // 一度変数にキャッシュしたりすると Illegal invocation になるので直接呼ぶ
     if(document.body.requestFullscreen != null){
         document.body.requestFullscreen();
-        wrap.classList.add('fullscreen');
     }else if(document.body.webkitRequestFullScreen != null){
         document.body.webkitRequestFullScreen();
-        wrap.classList.add('fullscreen');
     }
+
+    wrap.classList.add('fullscreen');
+    unregisterCursorTimeout = registerCursorTimeout(wrap);
+
     editor.resize();
     audioEditor.resize();
     resize();

--- a/src/script.js
+++ b/src/script.js
@@ -26,9 +26,6 @@ let download   = null; // download button
 let link       = null; // generate link button
 let layer      = null; // dialog layer
 let dialog     = null; // dialog message wrapper
-let canvasWrap = null; // canvas を包んでいるラッパー DOM
-let editorWrap = null; // editor を包んでいるラッパー DOM
-let iconColumn = null; // icon を包んでいるラッパー DOM
 let infoIcon   = null; // information icon
 let fullIcon   = null; // fullscreen icon
 let broadIcon  = null; // broadcast mode icon
@@ -143,9 +140,6 @@ window.addEventListener('DOMContentLoaded', () => {
     link       = document.querySelector('#permanentlink');
     layer      = document.querySelector('#layer');
     dialog     = document.querySelector('#dialogmessage');
-    canvasWrap = document.querySelector('#canvaswrap');
-    editorWrap = document.querySelector('#editorwrap');
-    iconColumn = document.querySelector('#globaliconcolumn');
     infoIcon   = document.querySelector('#informationicon');
     fullIcon   = document.querySelector('#fullscreenicon');
     broadIcon  = document.querySelector('#broadcasticon');
@@ -2285,9 +2279,8 @@ function exitFullscreen(){
  * フルスクリーンを解除後の DOM 操作とエディタ領域のリサイズのみを行う
  */
 function exitFullscreenMode(){
-    canvasWrap.classList.remove('fullscreen');
-    editorWrap.classList.remove('invisible');
-    iconColumn.classList.remove('invisible');
+    wrap.classList.remove('fullscreen');
+
     editor.resize();
     audioEditor.resize();
     resize();
@@ -2307,14 +2300,10 @@ function requestFullscreenMode(){
     // 一度変数にキャッシュしたりすると Illegal invocation になるので直接呼ぶ
     if(document.body.requestFullscreen != null){
         document.body.requestFullscreen();
-        canvasWrap.classList.add('fullscreen');
-        editorWrap.classList.add('invisible');
-        iconColumn.classList.add('invisible');
+        wrap.classList.add('fullscreen');
     }else if(document.body.webkitRequestFullScreen != null){
         document.body.webkitRequestFullScreen();
-        canvasWrap.classList.add('fullscreen');
-        editorWrap.classList.add('invisible');
-        iconColumn.classList.add('invisible');
+        wrap.classList.add('fullscreen');
     }
     editor.resize();
     audioEditor.resize();

--- a/src/script.js
+++ b/src/script.js
@@ -976,12 +976,12 @@ window.addEventListener('DOMContentLoaded', () => {
 
     // hide menu
     hideIcon.addEventListener('click', () => {
-        toggleLayerView();
+        setLayerView(true);
     }, false);
 
     // show menu
     showIcon.addEventListener('click', () => {
-        toggleLayerView();
+        setLayerView(false);
     }, false);
 
     // toggle menu
@@ -1438,14 +1438,30 @@ function resize(){
 
 /**
  * レイヤービューの変更
+ *
+ * `true` を渡すと、エディタが隠れてシェーダが全画面で実行される状態になる
+ * `false` を渡すと、その状態が解除される
  */
-function toggleLayerView(){
-    wrap.classList.toggle('hide');
+function setLayerView(value){
+    if (value) {
+        wrap.classList.add('hide');
+    } else {
+        wrap.classList.remove('hide');
+    }
 
     editor.resize();
     audioEditor.resize();
     resize();
     fragmen.rect();
+}
+
+/**
+ * レイヤービューの変更
+ *
+ * {@link setLayerView} と違い、こちらはトグル
+ */
+function toggleLayerView(){
+    setLayerView(!wrap.classList.contains('hide'));
 }
 
 /**

--- a/src/script.js
+++ b/src/script.js
@@ -12,6 +12,7 @@ import 'firebase/analytics';
 
 (() => {
 
+let wrap       = null; // だいたいすべてを包んでいるラッパー DOM
 let canvas     = null; // スクリーン
 let editor     = null; // Ace editor のインスタンス
 let lineout    = null; // ステータスバー DOM
@@ -35,6 +36,7 @@ let starIcon   = null; // star icon
 let menuIcon   = null; // menu icon
 let noteIcon   = null; // note icon
 let hideIcon   = null; // hide menu icon
+let showIcon   = null; // show menu icon
 let syncToggle = null; // スクロール同期用のチェックボックス
 
 let audioWrap     = null; // サウンドシェーダペインのラッパー
@@ -128,6 +130,7 @@ window.addEventListener('DOMContentLoaded', () => {
     fire = new FireDB(firebase);
 
     // DOM への参照
+    wrap       = document.querySelector('#wrap');
     canvas     = document.querySelector('#webgl');
     lineout    = document.querySelector('#lineout');
     counter    = document.querySelector('#counter');
@@ -150,6 +153,7 @@ window.addEventListener('DOMContentLoaded', () => {
     menuIcon   = document.querySelector('#togglemenuicon');
     noteIcon   = document.querySelector('#noteicon');
     hideIcon   = document.querySelector('#hidemenuicon');
+    showIcon   = document.querySelector('#showmenuicon');
     syncToggle = document.querySelector('#syncscrolltoggle');
 
     audioWrap     = document.querySelector('#audio');
@@ -207,7 +211,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 isOwner = value === 'true';
                 break;
             case 'ol': // overlay (hide menu view)
-                document.querySelector('#wrap').classList.add('overlay');
+                wrap.classList.add('overlay');
                 isLayerHidden = true;
                 break;
         }
@@ -975,6 +979,11 @@ window.addEventListener('DOMContentLoaded', () => {
         toggleLayerView();
     }, false);
 
+    // show menu
+    showIcon.addEventListener('click', () => {
+        toggleLayerView();
+    }, false);
+
     // toggle menu
     menuIcon.addEventListener('click', () => {
         toggleEditorView();
@@ -1431,31 +1440,20 @@ function resize(){
  * レイヤービューの変更
  */
 function toggleLayerView(){
-    canvasWrap.classList.toggle('fullheight');
-    editorWrap.classList.toggle('invisible');
-    fullIcon.classList.toggle('invisible');
-    broadIcon.classList.toggle('invisible');
-    hideIcon.classList.toggle('hide');
-    menuIcon.classList.toggle('invisible');
-    noteIcon.classList.toggle('invisible');
+    wrap.classList.toggle('hide');
+
     editor.resize();
     audioEditor.resize();
     resize();
     fragmen.rect();
-
-    if(hideIcon.classList.contains('hide') === true){
-        hideIcon.title = 'hide editor';
-    }else{
-        hideIcon.title = 'show editor';
-    }
 }
 
 /**
  * エディタビューの変更
  */
 function toggleEditorView(){
-    const wrap = document.querySelector('#wrap');
     wrap.classList.toggle('overlay');
+
     editor.resize();
     audioEditor.resize();
     resize();


### PR DESCRIPTION
### 説明

- hide状態・fullscreen状態に関するリファクタリングを行いました。
    - `toggleEditorView` ・ `requestFullscreenMode` ・ `exitFullscreenMode` それぞれが各要素のCSSクラスに触っており、独立に状態を変更できないのを解決するため。
    - これまで `#wrap.overlay` でビューを制御していたのと同じノリで、 `#wrap.hide` ・ `#wrap.fullscreen` でレイアウト変更を行います。
    - コードとしても、前よりも読みやすくなったかと思います。
- 上記変更を踏まえて、hide状態からでもfullscreenボタンを押せるようにしました。
- フルスクリーン状態で、マウスカーソルを動かさずに2秒放置したら、自動でマウスカーソルが消えるようにしました。
    - これを実現するための関数 `registerCursorTimeout` を追加してます。

### レビュー観点

- [x] リファクタリングの方針は適切でしょうか？
- [x] `script.js` 内、新たに `#wrap` を `wrap` という変数名で定義しています。これは適切ですか？
- [x] `#hidemenuicon` と `#showmenuicon` を分離した点について、問題はありますか？
- [x] hide状態からfullscreenが押せなかった理由について、バグが起こっていたこと以外に理由がありましたか？
- [x] `registerCursorTimeout` の実装に不備はないでしょうか？
- [x] `src/registerCursorTimeout.js` というファイル命名はどう思いますか？
    - 他の択: `register-cursor-timeout.js` ・ `registercursortimeout.js` ・ そもそも別ファイルにしない
- [x] その他全体的に、記法に問題はありませんか？
    - たとえば、JS初心者にとって読解難易度の高すぎる表現が含まれていたりとか
